### PR TITLE
feat: allow merging custom NodeProp spec

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Cdaprod
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           config-file: '.nodeprop.yml'  # Optional: defaults to .nodeprop.yml
           storage-path: 'configs'        # Optional: path for content-addressable storage
+          spec-file: '.nodeprop.extra.yml'  # Optional: merge additional fields
 ```
 
 ## Inputs
@@ -49,6 +50,7 @@ jobs:
 | `github-token` | GitHub token for API access | Yes | N/A |
 | `config-file` | Name of the configuration file to generate | No | `.nodeprop.yml` |
 | `storage-path` | Path to store configurations | No | `configs` |
+| `spec-file` | Path to YAML file with extra NodeProp fields | No | `''` |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: 'Path to store configurations (if using content-addressable storage)'
     required: false
     default: 'configs'
+  spec-file:
+    description: 'Path to YAML file with additional NodeProp fields'
+    required: false
+    default: ''
 
 outputs:
   config-hash:
@@ -47,6 +51,7 @@ runs:
         CONFIG_FILE_NAME: ${{ inputs.config-file }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
         STORAGE_PATH: ${{ inputs.storage-path }}
+        SPEC_FILE_PATH: ${{ inputs.spec-file }}
 
     - name: Set Outputs
       shell: bash

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for nodeprop-action."""

--- a/tests/test_generate_config.py
+++ b/tests/test_generate_config.py
@@ -1,0 +1,86 @@
+"""Unit tests for ConfigGenerator.
+
+Run with:
+    python -m unittest tests.test_generate_config
+"""
+
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import yaml
+
+from scripts.generate_config import ConfigGenerator
+
+
+class ConfigGeneratorTest(unittest.TestCase):
+    def setUp(self):
+        self.env_patch = patch.dict(os.environ, {
+            "GITHUB_REPOSITORY": "Cdaprod/example",
+            "GITHUB_ACTOR": "tester",
+            "GITHUB_SHA": "abcdef1234567890"
+        })
+        self.env_patch.start()
+        self.addCleanup(self.env_patch.stop)
+
+    def test_generate_config_populates_fields(self):
+        cg = ConfigGenerator()
+        mock_metadata = {
+            "stars": 1,
+            "forks": 2,
+            "issues": 3,
+            "license": "MIT",
+            "latest_commit": "2025-01-01T00:00:00Z",
+            "topics": ["t1"],
+            "default_branch": "main"
+        }
+        with patch.object(cg, 'fetch_github_metadata', return_value=mock_metadata), \
+             patch.object(cg, 'detect_capabilities', return_value=['pipeline']), \
+             patch.object(cg, 'generate_network_identifiers', return_value={
+                 'namespace': 'Cdaprod-network',
+                 'domain': 'example.cdaprod.dev',
+                 'service_dns': 'svc',
+                 'cluster_dns': 'svc.cluster.local',
+                 'service_name': 'example'
+             }):
+            config = cg.generate_config()
+
+        self.assertEqual(config['metadata']['github']['stars'], 1)
+        self.assertIn('pipeline', config['capabilities'])
+        self.assertEqual(
+            config['metadata']['custom_properties']['image'],
+            'Cdaprod/example:abcdef1'
+        )
+        self.assertEqual(config['metadata']['github']['topics'], ['t1'])
+
+    def test_spec_file_merge(self):
+        spec = {'artifacts': {'backend': {'runtime': 'docker'}}}
+        with tempfile.NamedTemporaryFile('w', delete=False) as tmp:
+            yaml.safe_dump(spec, tmp)
+            spec_path = tmp.name
+        self.addCleanup(lambda: os.remove(spec_path))
+        env = patch.dict(os.environ, {"SPEC_FILE_PATH": spec_path})
+        env.start()
+        self.addCleanup(env.stop)
+
+        cg = ConfigGenerator()
+
+        mock_metadata = {
+            "stars": 0,
+            "forks": 0,
+            "issues": 0,
+            "license": "MIT",
+            "latest_commit": "2025-01-01T00:00:00Z",
+            "topics": [],
+            "default_branch": "main",
+        }
+        with patch.object(cg, 'fetch_github_metadata', return_value=mock_metadata), \
+             patch.object(cg, 'detect_capabilities', return_value=[]), \
+             patch.object(cg, 'generate_network_identifiers', return_value={'namespace': 'n', 'domain': 'd', 'service_dns': 's', 'cluster_dns': 'c', 'service_name': 'svc'}):
+            config = cg.generate_config()
+        self.assertEqual(config['artifacts']['backend']['runtime'], 'docker')
+
+
+if __name__ == '__main__':  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- support merging an optional spec file into generated NodeProp config
- document `spec-file` input for the action
- test spec merging and provide recursive merge helper

## Testing
- `python -m py_compile scripts/generate_config.py`
- `python -m unittest`

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [x] Docs updated where needed.

------
https://chatgpt.com/codex/tasks/task_e_689d1aef34108326a5a07b9fba64632f